### PR TITLE
수정 CLink, NoticeList의 경로 적용되지 않는 개선

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -8,7 +8,7 @@
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jst.j2ee.internal.web.container"/>
 	<classpathentry kind="con" path="org.eclipse.jst.j2ee.internal.module.container"/>
-	<classpathentry kind="con" path="org.eclipse.jst.server.core.container/org.eclipse.jst.server.tomcat.runtimeTarget/1113Server">
+	<classpathentry kind="con" path="org.eclipse.jst.server.core.container/org.eclipse.jst.server.tomcat.runtimeTarget/3_Project">
 		<attributes>
 			<attribute name="owner.project.facets" value="jst.web;#system#"/>
 		</attributes>

--- a/.settings/org.eclipse.wst.common.project.facet.core.xml
+++ b/.settings/org.eclipse.wst.common.project.facet.core.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <faceted-project>
-  <runtime name="1113Server"/>
+  <runtime name="3_Project"/>
   <fixed facet="java"/>
   <fixed facet="wst.jsdt.web"/>
   <fixed facet="jst.web"/>

--- a/src/main/webapp/SubPage/SCenter/Notice/List.jsp
+++ b/src/main/webapp/SubPage/SCenter/Notice/List.jsp
@@ -107,13 +107,13 @@
                     </tbody>
                 </table>
                 <div class="paging">
-                    <img src="img/fpage.gif" alt="처음페이지">
-                    <img src="img/back.gif" alt="이전페이지">
+                    <img src="/img/fpage.gif" alt="처음페이지">
+                    <img src="/img/back.gif" alt="이전페이지">
         
                     <strong>1</strong>
         
-                    <img src="img/next.gif" alt="다음페이지">
-                    <img src="img/lpage.gif" alt="마지막페이지">
+                    <img src="/img/next.gif" alt="다음페이지">
+                    <img src="/img/lpage.gif" alt="마지막페이지">
                 </div>
                 <form name="sform" method="post" action="#">
                     <div class="boardSch">

--- a/src/main/webapp/module/CLink.jsp
+++ b/src/main/webapp/module/CLink.jsp
@@ -8,10 +8,10 @@
 </head>
 <body>
 	<!--메인페이지 css-->
-	<link rel="stylesheet" href="css/Common.css">
-	<link rel="stylesheet" href="css/Header.css">
-	<link rel="stylesheet" href="css/NoticeList.css">	
-	<link rel="stylesheet" href="css/Footer.css">
+	<link rel="stylesheet" href="/css/Common.css">
+	<link rel="stylesheet" href="/css/Header.css">
+	<link rel="stylesheet" href="/css/NoticeList.css">	
+	<link rel="stylesheet" href="/css/Footer.css">
 
 </body>
 </html>

--- a/src/main/webapp/module/common/Header.jsp
+++ b/src/main/webapp/module/common/Header.jsp
@@ -14,7 +14,7 @@
         <div class="tWrap">
             <h1>
                 <a href="/Main.jsp">
-                <img src="img/hLogo.png">
+                <img src="/img/hLogo.png">
                 </a>
             </h1>
             <div class="tmenu">


### PR DESCRIPTION
Fix moudule CLink.jsp
Fix css NoticeList.css




원인: 서버에 최상위 경로가 지정되지 않았고 해당 링크 경로도 잘못 지정되어 있었음

결과: 메뉴탭 고객센터의 공지사항 서브페이지 수정
include로 불러온 css파일이 적용되지 않는 상황을 개선하였음